### PR TITLE
followup wayann "Fix wrong category link in blocklanguages"

### DIFF
--- a/cleanurls/override/classes/Link.php
+++ b/cleanurls/override/classes/Link.php
@@ -71,7 +71,7 @@ class Link extends LinkCore
 		{
 			//RETRIEVING ALL THE PARENT CATEGORIES
 			$cats = array();
-			foreach ($category->getParentsCategories() as $cat)
+			foreach ($category->getParentsCategories($id_lang) as $cat)
 			{
 				self::$category_disable_rewrite[] = $category->id;
 


### PR DESCRIPTION
when multilanguage is enabled if you had a rule with parent category blocklanguages module would parse the subcategory with the previous selected language.